### PR TITLE
fix: remove semantic release dependency on tests and remove vibe coded app.yml gtfs api inclusion (unused)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     name: Semantic Release
     runs-on: ubuntu-latest
-    needs: test
+    # needs: test
     permissions:
       contents: write
       issues: write

--- a/app.yaml
+++ b/app.yaml
@@ -3,12 +3,3 @@
 
 runtime: java17
 instance_class: F2
-
-gtfs:
-  api-token: YOUR_TOKEN_HERE
-  static-url: https://data.opentransportdata.swiss/dataset/timetable-2026-gtfs2020
-  rt-url: https://api.opentransportdata.swiss/la/gtfs-rt
-  # Where to cache the downloaded ZIP on disk
-  local-zip-path: /var/data/gtfs/gtfs_static.zip
-  # Reload static data every Monday at 03:00 (published ~twice/week)
-  reload-cron: "0 0 3 * * MON"


### PR DESCRIPTION
this should fix deployment to google cloud and make the semantic releases work